### PR TITLE
Deprovision now deletes ALL topics that have the Service ID as a prefix.

### DIFF
--- a/bin/sanity-test
+++ b/bin/sanity-test
@@ -11,6 +11,7 @@ function header() {
 
 export EDEN_CONFIG=${EDEN_CONFIG:-tmp/eden_config_sanity_test}
 mkdir -p $(dirname $EDEN_CONFIG)
+rm -rf $EDEN_CONFIG
 
 export SB_BROKER_URL=${SB_BROKER_URL:-http://localhost:8100}
 export SB_BROKER_USERNAME=${SB_BROKER_USERNAME:-}

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,1 +1,2 @@
+* Deprovision now deletes ALL topics that have the Service ID as a prefix. This means that you can use `topicName` as a prefix and dynamically create any number of topics that you need. Deprovision will clean them up with they are all named with `topicName` (the Service ID value) as the prefix.
 * `bin/sanity-test` uses `eden` CLI to show catalog/provision/bind/unbind/deprovision against a service broker

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,2 +1,4 @@
 * Deprovision now deletes ALL topics that have the Service ID as a prefix. This means that you can use `topicName` as a prefix and dynamically create any number of topics that you need. Deprovision will clean them up with they are all named with `topicName` (the Service ID value) as the prefix.
+
+  Remember, your Kafka `server.properties` needs to have `delete.topic.enable=true` configured to allow topics to be deleted. If `delete.topic.enable=false` then Deprovision will quietly ignore deleting topics and complete successfully.
 * `bin/sanity-test` uses `eden` CLI to show catalog/provision/bind/unbind/deprovision against a service broker


### PR DESCRIPTION
This means that you can use `topicName` as a prefix and dynamically create any number of topics that you need. Deprovision will clean them up with they are all named with `topicName` (the Service ID value) as the prefix.

Remember, your Kafka `server.properties` needs to have `delete.topic.enable=true` configured to allow topics to be deleted. If `delete.topic.enable=false` then Deprovision will quietly ignore deleting topics and complete successfully.